### PR TITLE
Fix MySQL version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ supports 'debian'
 
 depends "php"
 depends "apache2"
-depends "mysql"
+depends "mysql", "4.1.2"
 depends "composer"
 
 recipe 'laravel', 'Installs and configures Laravel and additional modules.'


### PR DESCRIPTION
Looks like there were some breaking changes in the last couple versions of the `mysql` cookbook. This reverts back to the latest version that works.
