### PR TITLE
Fix project path

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -21,7 +21,7 @@ module Laravel
 
     # Define the project path
     def project_path
-      "#{node['laravel']['project_root']}/#{node['laravel']['project_name']}"
+      "#{node['laravel']['project_root']}"
     end
 
 

--- a/templates/default/laravel.conf.erb
+++ b/templates/default/laravel.conf.erb
@@ -1,5 +1,5 @@
 <VirtualHost *:80>
-	DocumentRoot <%= "#{node['laravel']['project_root']}/#{node['laravel']['project_name']}" %>/public
+	DocumentRoot <%= "#{node['laravel']['project_root']}" %>/public
 	ServerName <%= "dev.#{node['laravel']['project_name']}.com" %>
 	CustomLog /var/log/apache2/<%= "dev.#{node['laravel']['project_name']}.com-access_log combined" %>
 	ErrorLog /var/log/apache2/<%= "dev.#{node['laravel']['project_name']}.com-error_log" %>


### PR DESCRIPTION
I think it makes more sense to define the path separately, instead of always including the project name as the final folder.

(Now that I think about it, this does match the folder structure on my production server, but not my development environment [a Vagrant VM].)

Was there a particular reason for having this folder structure?
