### PR TITLE
Fix composer command

### DIFF
--- a/recipes/laravel.rb
+++ b/recipes/laravel.rb
@@ -57,7 +57,7 @@ if ::File.exist?("#{path}/composer.json")
   # Update composer dependencies
   execute "Install Composer Packages" do
     action :run
-    command "cd #{path}; #{composer_command} update"
+    command "cd #{path}; #{composer_command} install"
   end
 
 # Create the composer config files if they do not already exist


### PR DESCRIPTION
If project already exists, install instead of update.

If I have an existing project, I generally prefer to only update it manually (because I also [commit my `composer.lock`](http://stackoverflow.com/questions/12896780/should-composer-lock-be-committed-to-version-control) to the Git repo).
